### PR TITLE
Add Setting to Make Tarps Consumable & Sort Them in Arsenal

### DIFF
--- a/addons/panel/functions/fnc_createPanel.sqf
+++ b/addons/panel/functions/fnc_createPanel.sqf
@@ -52,6 +52,11 @@ switch (_color) do {
 private _tarp = createVehicle [_classname, _position, [], 0, "CAN_COLLIDE"];
 _tarp enableSimulation false;
 
+if (GVAR(consume)) then {
+    private _itemName = QPVAR(Panel) + _color; // Get appropiate item name
+    _tarp setVariable [QGVAR(itemName), _itemName, true];
+    _player removeItem _itemName;
+};
 
 private "_posHelper";
 if (_small) then {

--- a/addons/panel/functions/fnc_statementPanelRemove.sqf
+++ b/addons/panel/functions/fnc_statementPanelRemove.sqf
@@ -17,7 +17,7 @@
 
 params [["_target", objNull, [objNull]]];
 
-private _object = (nearestObjects [_target, [
+private _tarp = (nearestObjects [_target, [
     "Tarp_01_Large_Green_F",
     "Tarp_01_Small_Green_F",
     "Tarp_01_Large_Black_F",
@@ -29,7 +29,12 @@ private _object = (nearestObjects [_target, [
 ], 10]) select 0;
 private _grasscutter = nearestObject [_target, "Land_ClutterCutter_large_F"];
 
-deleteVehicle _object;
+if (GVAR(consume)) then {
+    private _itemName = _tarp getVariable [QGVAR(itemName), ""];
+    [ace_player, _itemName, true] call CBA_fnc_addItem;
+};
+
+deleteVehicle _tarp;
 deleteVehicle _grasscutter;
 deleteVehicle _target;
 

--- a/addons/panel/initSettings.sqf
+++ b/addons/panel/initSettings.sqf
@@ -6,3 +6,12 @@
     [true],
     true
 ] call CBA_Settings_fnc_init;
+
+[
+    QGVAR(consume),
+    "CHECKBOX",
+    [localize LSTRING(consume), localize LSTRING(consumeDesc)],
+    QUOTE(PREFIX),
+    false,
+    true
+] call CBA_fnc_addSetting;

--- a/addons/panel/stringtable.xml
+++ b/addons/panel/stringtable.xml
@@ -2,7 +2,7 @@
 <Project name="KNB">
     <Package name="panel">
         <Key ID="STR_KNB_panel_cba_open">
-            <English>Ability to place panels with ace intercation</English>
+            <English>Ability to place panels with ace interaction</English>
             <German>Möglichkeit panels über ACE Interaktion zu plazieren</German>
             <Chinese>能夠透過ACE互動來放置頁面</Chinese>
         </Key>
@@ -15,6 +15,12 @@
             <English>Pick panel up</English>
             <German>Hebe panel auf</German>
             <Chinese>撿起頁面</Chinese>
+        </Key>
+        <Key ID="STR_KNB_panel_consume">
+            <English>Consume Panel Items</English>
+        </Key>
+        <Key ID="STR_KNB_panel_consumeDesc">
+            <English>Panels are removed from inventory when placed down, and added when picked up</English>
         </Key>
         <Key ID="STR_KNB_panel_red">
             <English>Red</English>

--- a/addons/panelitem/stringtable.xml
+++ b/addons/panelitem/stringtable.xml
@@ -2,18 +2,18 @@
 <Project name="KNB">
     <Package name="panelitem">
         <Key ID="STR_KNB_panelitem_red">
-            <English>Red panel</English>
-            <German>Rotes Panel</German>
+            <English>Panel (Red)</English>
+            <German>Panel (Rotes)</German>
             <Chinese>紅頁面</Chinese>
         </Key>
         <Key ID="STR_KNB_panelitem_yellow">
-            <English>Yellow panel</English>
-            <German>Gelbes Panel</German>
+            <English>Panel (Yellow)</English>
+            <German>Panel (Gelbes)</German>
             <Chinese>黃頁面</Chinese>
         </Key>
         <Key ID="STR_KNB_panelitem_green">
-            <English>Green panel</English>
-            <German>Grünes Panel</German>
+            <English>Panel (Green)</English>
+            <German>Panel (Grünes)</German>
             <Chinese>綠頁面</Chinese>
         </Key>
     </Package>


### PR DESCRIPTION
I want to give people the ability to place down signals, but not necessarily infinite amounts of them. The setting is turned off by default to keep backwards compatibility.

Code _should_ be good to go but I haven't tested it yet.